### PR TITLE
Review syntax for Extensions

### DIFF
--- a/src/auth_scheme/private_token.ts
+++ b/src/auth_scheme/private_token.ts
@@ -298,8 +298,10 @@ export class Extension {
     //
     // struct {
     //     ExtensionType extension_type;
-    //     opaque extension_data<0..2^16-1>;
+    //     opaque extension_data<0..2^16-4-1>;
     // } Extension;
+
+    static MAX_EXTENSION_DATA_LENGTH = MAX_UINT16 - 4;
 
     constructor(
         public extensionType: ExtensionType,
@@ -310,8 +312,8 @@ export class Extension {
                 'invalid value for extension type, MUST be an integer between 0 and 2^16-1',
             );
         }
-        if (extensionData.length > MAX_UINT16) {
-            throw new Error('invalid extension data size. Max size is 2^16-1.');
+        if (extensionData.length > Extension.MAX_EXTENSION_DATA_LENGTH) {
+            throw new Error('invalid extension data size. Max size is 2^16-4-1.');
         }
     }
 

--- a/test/auth_scheme_with_extensions.test.ts
+++ b/test/auth_scheme_with_extensions.test.ts
@@ -116,22 +116,23 @@ test.each(tokenVectors)('AuthScheme-TokenVector-%#', async (v: TokenVectors) => 
 
 describe('extensions', () => {
     test('maxSizeExtension', () => {
-        const ext = new Extension(0xaa, new Uint8Array(MAX_UINT16));
+        const ext = new Extension(0xaa, new Uint8Array(Extension.MAX_EXTENSION_DATA_LENGTH));
         testSerializeWithOps(Extension, ext);
 
         const extBytes = ext.serialize();
-        expect(extBytes.length).toBe(2 + 2 + MAX_UINT16);
+        expect(extBytes.length).toBe(2 + 2 + Extension.MAX_EXTENSION_DATA_LENGTH);
     });
 
     test('maxSizeArrayExtension', () => {
-        const ext = new Extension(0xaa, new Uint8Array(MAX_UINT16));
+        const ext = new Extension(0xaa, new Uint8Array(Extension.MAX_EXTENSION_DATA_LENGTH));
         const arrayExt = new Extensions([ext]);
 
         testSerialize(Extensions, arrayExt);
 
         const arrayExtBytes = arrayExt.serialize();
         expect(arrayExtBytes.length).toBe(
-            2 /* <-- This prefix should be at least 4 bytes. */ + (2 + 2 + MAX_UINT16),
+            2 /* <-- This prefix should be at least 4 bytes. */ +
+                (2 + 2 + Extension.MAX_EXTENSION_DATA_LENGTH),
         );
     });
 

--- a/test/auth_scheme_with_extensions.test.ts
+++ b/test/auth_scheme_with_extensions.test.ts
@@ -18,12 +18,6 @@ type TokenVectors = (typeof tokenVectors)[number];
 
 const MAX_UINT16 = (1 << 16) - 1;
 
-function u8AreEqual(a: Uint8Array, b: Uint8Array): boolean {
-    if (a.byteLength !== b.byteLength) return false;
-    // eslint-disable-next-line security/detect-object-injection
-    return a.every((val, i) => val === b[i]);
-}
-
 describe('PublicVerifiableMetadata failing edge case', () => {
     test('Invalid extension number', () => {
         function invalidExtensionConstructor() {
@@ -58,7 +52,7 @@ describe('PublicVerifiableMetadata failing edge case', () => {
         }
         const extensions = extensionsConstructor();
         const serialized = extensions.serialize();
-        expect(u8AreEqual(serialized, new Uint8Array([0, 8, 0, 1, 0, 0, 0, 2, 0, 0]))).toBe(true);
+        expect(serialized).toStrictEqual(new Uint8Array([0, 8, 0, 1, 0, 0, 0, 2, 0, 0]));
     });
 
     test('Repeated extension type', () => {
@@ -70,7 +64,7 @@ describe('PublicVerifiableMetadata failing edge case', () => {
         }
         const extensions = extensionsConstructor();
         const serialized = extensions.serialize();
-        expect(u8AreEqual(serialized, new Uint8Array([0, 8, 0, 1, 0, 0, 0, 1, 0, 0]))).toBe(true);
+        expect(serialized).toStrictEqual(new Uint8Array([0, 8, 0, 1, 0, 0, 0, 1, 0, 0]));
     });
 
     test('Extensions 0 and MAX_UINT type', () => {
@@ -82,9 +76,7 @@ describe('PublicVerifiableMetadata failing edge case', () => {
         }
         const extensions = extensionsConstructor();
         const serialized = extensions.serialize();
-        expect(u8AreEqual(serialized, new Uint8Array([0, 8, 0, 0, 0, 0, 255, 255, 0, 0]))).toBe(
-            true,
-        );
+        expect(serialized).toStrictEqual(new Uint8Array([0, 8, 0, 0, 0, 0, 255, 255, 0, 0]));
     });
 
     test('Too many extensions', () => {

--- a/test/util.ts
+++ b/test/util.ts
@@ -29,6 +29,21 @@ export function testSerialize(classType: CanDeserialize<CanSerialize>, instance:
     expect(got).toStrictEqual(instance);
 }
 
+interface CanDeserializeWithOps<T extends CanSerialize> {
+    deserialize(_b: Uint8Array, ops: { bytesRead: number }): T;
+}
+
+export function testSerializeWithOps(
+    classType: CanDeserializeWithOps<CanSerialize>,
+    instance: CanSerialize,
+) {
+    const bytes = instance.serialize();
+    const ops = { bytesRead: 0 };
+    const got = classType.deserialize(bytes, ops);
+    expect(got).toStrictEqual(instance);
+    expect(ops.bytesRead).toBe(bytes.length);
+}
+
 interface CanDeserializeWithType<T extends CanSerialize> {
     deserialize(type: TokenTypeEntry, _b: Uint8Array): T;
 }


### PR DESCRIPTION
I consider there is an error in the specification of `Extensions`.
It should be from 0 to 2^32-1

```diff
struct {
    ExtensionType extension_type;
    opaque extension_data<0..2^16-1>;
} Extension;

enum {
    reserved(0),
    (65535)
} ExtensionType;

struct {
-    Extension extensions<0..2^16-1>;
+    Extension extensions<0..2^32-1>;
} Extensions;
```

this is because the maximum valid length of `Extension` is 
```md
  2 bytes for `ExtensionType`
+ 2 bytes for prefix
+ 2^16-1 bytes for `extension_data`
= 2^16+3, which cannot fit in a `Extensions` structure.
```